### PR TITLE
Feature: Use Aws::SharedCredentials

### DIFF
--- a/bima-deployment.gemspec
+++ b/bima-deployment.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # specify any dependencies here:
-  s.add_dependency 'aws-sdk', '~> 2.0'
+  s.add_dependency 'aws-sdk', '~> 2.4'
   s.add_dependency 'activesupport'
 
   # specify any development dependencies here:

--- a/lib/bima_deployment/opsworks/configuration.rb
+++ b/lib/bima_deployment/opsworks/configuration.rb
@@ -1,9 +1,10 @@
 module BimaDeployment
   module Opsworks
     class Configuration
-      def self.load_credentials
+      def self.load_credentials(profile = nil)
         begin
-          shared_credentials = Aws::SharedCredentials.new(profile_name: 'bima')
+          profile ||= 'bima'
+          shared_credentials = Aws::SharedCredentials.new(profile_name: profile)
         rescue Aws::Errors::NoSuchProfileError
           shared_credentials = Aws::SharedCredentials.new(profile_name: 'default')
         end

--- a/lib/bima_deployment/opsworks/configuration.rb
+++ b/lib/bima_deployment/opsworks/configuration.rb
@@ -2,6 +2,9 @@ module BimaDeployment
   module Opsworks
     class Configuration
       def self.load_credentials(profile = nil)
+        return unless File.exists?(Aws.shared_config.config_path) ||
+                      File.exists?(Aws.shared_config.credentials_path)
+
         begin
           profile ||= 'bima'
           shared_credentials = Aws::SharedCredentials.new(profile_name: profile)

--- a/lib/bima_deployment/opsworks/configuration.rb
+++ b/lib/bima_deployment/opsworks/configuration.rb
@@ -2,15 +2,13 @@ module BimaDeployment
   module Opsworks
     class Configuration
       def self.load_credentials
-        credentials_path = File.expand_path('~/.aws/credentials')
-        config = {}.with_indifferent_access
-
-        File.readlines(credentials_path).select { |line| line.starts_with?('aws') }.each do |line|
-          key, value = line.split('=').map(&:strip)
-          config[key] = value
+        begin
+          shared_credentials = Aws::SharedCredentials.new(profile_name: 'bima')
+        rescue Aws::Errors::NoSuchProfileError
+          shared_credentials = Aws::SharedCredentials.new(profile_name: 'default')
         end
 
-        set_credentials(config[:aws_access_key_id], config[:aws_secret_access_key])
+        Aws.config.update(credentials: shared_credentials.credentials)
       end
 
       protected

--- a/lib/bima_deployment/opsworks/configuration.rb
+++ b/lib/bima_deployment/opsworks/configuration.rb
@@ -11,13 +11,6 @@ module BimaDeployment
 
         Aws.config.update(credentials: shared_credentials.credentials)
       end
-
-      protected
-
-      def self.set_credentials(access_key, secret_key)
-        credentials = Aws::Credentials.new(access_key, secret_key)
-        Aws.config.update(credentials: credentials)
-      end
     end
   end
 end

--- a/lib/bima_deployment/strategies/opsworks/base.rb
+++ b/lib/bima_deployment/strategies/opsworks/base.rb
@@ -15,6 +15,8 @@ module BimaDeployment
 
         def confirm(current_revision)
           last_deployment = BimaDeployment::Opsworks::Deployment.last(app: app, client: client)
+          return if last_deployment.nil?
+
           user = last_deployment.user
           timestamp = DateTime.parse(last_deployment.created_at)
 


### PR DESCRIPTION
Instead of parsing that `.ini` file in disguise ourselves, which is error-prone among other things, we just use `Aws::SharedCredentials` and live a happy life after, as [suggested by @jdahlke](https://github.com/jdahlke/bima-deployment/pull/2#discussion_r84466858):

``` ruby
def self.load_credentials
  sc = Aws::SharedCredentials.new(path: File.expand_path("~/.aws/credentials"))
  Aws.config.update(credentials: sc.credentials)
end
```

There is no need to provide `~/.aws/credentials` as a path, because `Aws::SharedCredentials` automagically checks `~/.aws/config` and `~/.aws/credentials`. Add in the following feature and there shouldn't ever be any need for a non-standard credentials file location.

However, I added a twist to the automagic credentials loading: _profiles_.
---
### Profiles

Some of us might have different sets of AWS credentials in their `~/.aws/credentials` files, since it's supported. So I think it makes sense to check for a profile called `bima` first, before falling back to the `default` profile, which most people have set up in order to get previous versions of `bima-deployment` to work.

If there is a need for configurable profile names for some reason, we can easily pass the profile name to `BimaDeployment::Opsworks::Configuration.load_credentials`, using a value from `BimaDeployment.config`. For now, it's possible to override the profile used for credentials with something like this:

``` ruby
BimaDeployment::Opsworks::Configuration.load_credentials('some-other-profile')
```

I think that, if needed, a feasible workaround would be stating that in `config/initializers/deployment.rb` for the time being.
