### PR TITLE
Feature: Generators for config files

### DIFF
--- a/lib/bima_deployment/rails.rb
+++ b/lib/bima_deployment/rails.rb
@@ -3,15 +3,25 @@ module BimaDeployment
     class InstallGenerator < Rails::Generators::NamedBase
       source_root File.expand_path('../../templates', __FILE__)
 
+      class_option :strategy, type: :string, default: 'opsworks/s3'
+      class_option :slack, type: :string, default: 'https://hooks.slack.com/services/get-your-own-url'
+
       def copy_files
         config_files = %w(
           config/deployment.yml
           config/initializers/deployment.rb
         )
+        replacements = {
+          STACK: name,
+          APP: name.downcase,
+          STRATEGY: options[:strategy],
+          SLACK_URL: options[:slack]
+        }
         config_files.each do |config_file|
           copy_file(config_file)
-          gsub_file(config_file, 'STACK', name)
-          gsub_file(config_file, 'APP', name.downcase)
+          replacements.each_pair do |key, value|
+            gsub_file(config_file, key.to_s, value.to_s)
+          end
         end
       end
     end

--- a/lib/bima_deployment/rails.rb
+++ b/lib/bima_deployment/rails.rb
@@ -1,13 +1,31 @@
 module BimaDeployment
-  if Object.const_defined?(:Rails) and Rails.const_defined?(:Railtie)
-    # @private
-    class Railtie < Rails::Railtie
-      rake_tasks do
-        load 'tasks/deploy.rake'
-        load 'tasks/package.rake'
-      end
+  if Object.const_defined?(:Rails)
+    class InstallGenerator < Rails::Generators::NamedBase
+      source_root File.expand_path('../../templates', __FILE__)
 
-      initializer 'bima_deployment.initialize' do |app|
+      def copy_files
+        config_files = %w(
+          config/deployment.yml
+          config/initializers/deployment.rb
+        )
+        config_files.each do |config_file|
+          copy_file(config_file)
+          gsub_file(config_file, 'STACK', name)
+          gsub_file(config_file, 'APP', name.downcase)
+        end
+      end
+    end
+
+    if Rails.const_defined?(:Railtie)
+      # @private
+      class Railtie < Rails::Railtie
+        rake_tasks do
+          load 'tasks/deploy.rake'
+          load 'tasks/package.rake'
+        end
+
+        initializer 'bima_deployment.initialize' do |app|
+        end
       end
     end
   end

--- a/lib/bima_deployment/rails.rb
+++ b/lib/bima_deployment/rails.rb
@@ -4,6 +4,8 @@ module BimaDeployment
       source_root File.expand_path('../../templates', __FILE__)
 
       class_option :strategy, type: :string, default: 'opsworks/s3'
+
+      class_option :notifications, type: :boolean, default: true
       class_option :slack, type: :string, default: 'https://hooks.slack.com/services/get-your-own-url'
 
       def copy_files
@@ -11,18 +13,7 @@ module BimaDeployment
           config/deployment.yml
           config/initializers/deployment.rb
         )
-        replacements = {
-          STACK: name,
-          APP: name.downcase,
-          STRATEGY: options[:strategy],
-          SLACK_URL: options[:slack]
-        }
-        config_files.each do |config_file|
-          copy_file(config_file)
-          replacements.each_pair do |key, value|
-            gsub_file(config_file, key.to_s, value.to_s)
-          end
-        end
+        config_files.each { |config_file| template(config_file) }
       end
     end
 

--- a/lib/bima_deployment/rails.rb
+++ b/lib/bima_deployment/rails.rb
@@ -12,7 +12,6 @@ module BimaDeployment
         def copy_files
           config_files = %w(
             config/deployment.yml
-            config/initializers/deployment.rb
           )
           config_files.each { |config_file| template(config_file) }
         end
@@ -28,6 +27,12 @@ module BimaDeployment
         end
 
         initializer 'bima_deployment.initialize' do |app|
+          deployment_config = app.config_for(:deployment).with_indifferent_access
+
+          BimaDeployment.configure do |config|
+            config.deployment = deployment_config[:deployment]
+            config.notification = deployment_config[:notification]
+          end
         end
       end
     end

--- a/lib/bima_deployment/rails.rb
+++ b/lib/bima_deployment/rails.rb
@@ -1,19 +1,21 @@
 module BimaDeployment
   if Object.const_defined?(:Rails)
-    class InstallGenerator < Rails::Generators::NamedBase
-      source_root File.expand_path('../../templates', __FILE__)
+    if Rails.const_defined?(:Generators)
+      class InstallGenerator < Rails::Generators::NamedBase
+        source_root File.expand_path('../../templates', __FILE__)
 
-      class_option :strategy, type: :string, default: 'opsworks/s3'
+        class_option :strategy, type: :string, default: 'opsworks/s3'
 
-      class_option :notifications, type: :boolean, default: true
-      class_option :slack, type: :string, default: 'https://hooks.slack.com/services/get-your-own-url'
+        class_option :notifications, type: :boolean, default: true
+        class_option :slack, type: :string, default: 'https://hooks.slack.com/services/get-your-own-url'
 
-      def copy_files
-        config_files = %w(
-          config/deployment.yml
-          config/initializers/deployment.rb
-        )
-        config_files.each { |config_file| template(config_file) }
+        def copy_files
+          config_files = %w(
+            config/deployment.yml
+            config/initializers/deployment.rb
+          )
+          config_files.each { |config_file| template(config_file) }
+        end
       end
     end
 

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -5,7 +5,7 @@ end
 namespace :deploy do
   %i(development staging production).each do |environment|
     desc "Deploy to #{environment} environment on OpsWorks."
-    task environment, [:git_tag] do |_, args|
+    task environment, [:git_tag] => :environment do |_, args|
       BimaDeployment.load_configuration
       git_tag = args[:git_tag] || default_git_tag
       deployment = BimaDeployment::Deployment.new(environment, git_tag)

--- a/lib/templates/config/deployment.yml
+++ b/lib/templates/config/deployment.yml
@@ -3,7 +3,7 @@ defaults:
     strategy: 'opsworks/s3'
   notification: &notification_defaults
     slack:
-      url: 'https://hooks.slack.com/services/get-your-own-url'
+      url: 'SLACK_URL'
       enabled: true
 
 development:

--- a/lib/templates/config/deployment.yml
+++ b/lib/templates/config/deployment.yml
@@ -1,29 +1,29 @@
 defaults:
   deployment: &deployment_defaults
-    strategy: 'opsworks/s3'
+    strategy: '<%= options[:strategy] %>'
   notification: &notification_defaults
     slack:
-      url: 'SLACK_URL'
-      enabled: true
+      url: '<%= options[:slack] %>'
+      enabled: <%= options[:notifications] %>
 
 development:
   deployment:
     <<: *deployment_defaults
-    stack: 'STACK (Staging)'
-    app: 'APP_develop'
+    stack: '<%= name %> (Staging)'
+    app: '<%= name.downcase %>_develop'
   notification:
 
 staging:
   deployment:
     <<: *deployment_defaults
-    stack: 'STACK (Staging)'
-    app: 'APP_staging'
+    stack: '<%= name %> (Staging)'
+    app: '<%= name.downcase %>_staging'
   notification:
 
 production:
   deployment:
     <<: *deployment_defaults
-    stack: 'STACK (Production)'
-    app: 'APP'
+    stack: '<%= name %> (Production)'
+    app: '<%= name.downcase %>'
   notification:
     <<: *notification_defaults

--- a/lib/templates/config/deployment.yml
+++ b/lib/templates/config/deployment.yml
@@ -1,0 +1,29 @@
+defaults:
+  deployment: &deployment_defaults
+    strategy: 'opsworks/s3'
+  notification: &notification_defaults
+    slack:
+      url: 'https://hooks.slack.com/services/get-your-own-url'
+      enabled: true
+
+development:
+  deployment:
+    <<: *deployment_defaults
+    stack: 'STACK (Staging)'
+    app: 'APP_develop'
+  notification:
+
+staging:
+  deployment:
+    <<: *deployment_defaults
+    stack: 'STACK (Staging)'
+    app: 'APP_staging'
+  notification:
+
+production:
+  deployment:
+    <<: *deployment_defaults
+    stack: 'STACK (Production)'
+    app: 'APP'
+  notification:
+    <<: *notification_defaults

--- a/lib/templates/config/initializers/deployment.rb
+++ b/lib/templates/config/initializers/deployment.rb
@@ -1,6 +1,0 @@
-deployment_config = Rails.application.config_for(:deployment).with_indifferent_access
-
-BimaDeployment.configure do |config|
-  config.deployment = deployment_config[:deployment]
-  config.notification = deployment_config[:notification]
-end

--- a/lib/templates/config/initializers/deployment.rb
+++ b/lib/templates/config/initializers/deployment.rb
@@ -1,0 +1,6 @@
+deployment_config = Rails.application.config_for(:deployment).with_indifferent_access
+
+BimaDeployment.configure do |config|
+  config.deployment = deployment_config[:deployment]
+  config.notification = deployment_config[:notification]
+end


### PR DESCRIPTION
Obviously, I'm too lazy to even cook some copypasta to roll out `bima-deployment` on as many projects as possible. So I came up with this PR to maximise my laziness.
# What is this?

``` ruby
bundle exec rails g bima_deployment:install NAME
```

creates a boilerplate `config/deployment.yml` file. The template for this file can be found in `lib/templates/config/deployment.yml`. The `options` hash from the Rails generator is accessible in that template via ERb.

# Options

There are two command-line options for this generator:
- `strategy`, defaults to `opsworks/s3'
- `slack`, defaults to 'https://hooks.slack.com/services/get-your-own-url'

# Example

``` ruby
bundle exec rails g bima_deployment:install DerpCRM
```

will create a file `config/deployment.yml`

``` yml
defaults:
  deployment: &deployment_defaults
    strategy: 'opsworks/s3'
  notification: &notification_defaults
    slack:
      url: 'https://hooks.slack.com/services/get-your-own-url'
      enabled: true

development:
  deployment:
    <<: *deployment_defaults
    stack: 'DerpCRM (Staging)'
    app: 'derpcrm_develop'
  notification:

staging:
  deployment:
    <<: *deployment_defaults
    stack: 'DerpCRM (Staging)'
    app: 'derpcrm_staging'
  notification:

production:
  deployment:
    <<: *deployment_defaults
    stack: 'DerpCRM (Production)'
    app: 'derpcrm'
  notification:
    <<: *notification_defaults
```