### PR TITLE
Feature/remove deployment initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bima-deployment
+
 BImA deployment rake task
 
 
@@ -7,28 +8,10 @@ BImA deployment rake task
 Add this to your Gemfile:
 
 ```ruby
-group :development do
+group :development, :test do
   gem 'bima-deployment', git: 'https://github.com/jdahlke/bima-deployment.git', tag: '2.0.3'
 end
 ```
-
-You can add a `deployment.rb` initializer to fine-tune the deployment
-configuration.
-
-```ruby
-if defined?(BimaDeployment)
-  BimaDeployment.excluded = %w(
-    config/settings.yml
-    config/aws.yml
-    config/crm.yml
-    config/database.yml
-    .gitignore
-    .travis.yml
-    .rspec
-  )
-end
-```
-
 
 ### Rails generator `bima_deployment:install`
 
@@ -38,40 +21,53 @@ By invoking
 $ bundle exec rails g bima_deployment:install NAME
 ```
 
-you generate a `config/deployment.yml` file via the Rails generator process. 
+you generate a `config/deployment.yml` file via the Rails generator process.
 
 #### Mandatory arguments
 
 `NAME` is used for OpsWorks stack and app names in different ways:
 
-* Stack names will be `NAME (Staging)` for development and staging environments, 
+* Stack names will be `NAME (Staging)` for development and staging environments,
   `NAME (Production)` for the production environment.
-* App names will be `name_develop` and `name_staging` for development and staging 
+* App names will be `name_develop` and `name_staging` for development and staging
   environments respectively, `name` for the production environment.
-    
+
 #### Options
- 
+
 * `--notification` can be either `true` or `false` to specify whether you want
    to be notified after a successful deployment to production environments.
    Default: `true`.
 * `--slack` provides the URI to your Slack Incoming WebHook.
 * `--strategy` should be either `opsworks/git` or `opsworks/s3` to specify your
   deployment strategy. Default: `opsworks/s3`.
-                      
+
 #### Example
-                      
+
 ```sh
 $ bundle exec rails g bima_deployment:install MyApp \
         --slack=https://hooks.slack.com/services/URI/to/my/webhook \
-        --strategy=opsworks/git       
+        --strategy=opsworks/git
 ```
 
-                                          
+
+### Usage
+
+1. Run `bundle exec rake deploy[TAG_OR_BRANCH_NAME]` to deploy your code to AWS.
+   As the `opsworks/s3` strategy requires uploading a sizable file to S3 first,
+   this process can take a while.
+1. Get a cup of tea (or coffee) and watch your code being deployed to AWS for you.
+
+
 ### Rake tasks
+
+**Note:** Credentials for AWS related operations are automagically loaded from `~/.aws/credentials`.
+The rake taks will try to read credentials from a profile `[bima]`. If it fails, it will fallback to `[default]`.
 
 #### `deploy[git_ref]`
 
 Invokes `deploy:development[git_ref]`.
+
+**Note:** If git_tag is not provided, this will deploy the currently checked out revision (HEAD), not master.
 
 #### `deploy:development[git_ref]`
 
@@ -84,30 +80,11 @@ Deploys `git_ref` of your repository to your AWS OpsWorks production stack.
 #### `deploy:staging[git_ref]`
 
 Deploys `git_ref` of your repository to your AWS OpsWorks staging stack.
-                       
+
 #### `package[git_ref]`
-                                          
-Invokes `package:build[git_ref]`,  `package:upload[git_ref]`, and `package:cleanup`.
 
-#### `package:build[git_ref]`
-                                              
-Creates a working copy of `git_ref` of your repository in `tmp/package` and 
-packs it into a `.tbz2` file in `tmp/releases`.
-
-#### `package:cleanup`
-
+Creates a working copy of `git_ref` of your repository in `tmp/package` and
+packs it into a `.tbz2` file in `tmp/releases`. Uploads the release file for `git_ref` to S3.
 Cleans up the `tmp/package` and `tmp/releases` folders.
 
-#### `package:upload[git_ref]`
 
-Uploads the release file for `git_ref` to S3.
-
-
-### Usage
-
-1. Commit **all** changes you want to deploy. You do not have to push your
-   changes to GitHub, iff you are using `opsworks/s3`.
-1. Run `bundle exec rake deploy[TAG_OR_BRANCH_NAME]` to deploy your code to AWS.
-   As the `opsworks/s3` strategy requires uploading a sizable file to S3 first,
-   this process can take a while.
-1. Get a cup of tea (or coffee) and watch your code being deployed to AWS for you.   

--- a/lib/bima-deployment.rb
+++ b/lib/bima-deployment.rb
@@ -39,17 +39,11 @@ module BimaDeployment
       self.configure do |config|
         config.deployment = deployment_config[:deployment]
         config.notification = deployment_config[:notification]
+        config.package = deployment_config[:package]
       end
     end
-
-    initializer_path = Rails.root.join('config', 'initializers', self.config.configuration_file)
-    if File.exists?(initializer_path)
-      puts "Using deployment configuration from #{initializer_path}"
-      require initializer_path
-    else
-      puts "No deployment configuration found => using defaults"
-    end
   end
+
 
   #
   # Initial configuration
@@ -60,23 +54,10 @@ module BimaDeployment
   end
   config = Configuration.new
   config.logger = logger
-  config.configuration_file = 'deployment.rb'
   config.s3 = {
     bucket_name: 'bima-releases-ireland',
     region: 'eu-west-1'
   }
-
-  config.included = %w()
-
-  config.excluded = %w(
-    .gitignore
-    .travis.yml
-    .rspec
-    .git
-    client/node_modules
-    spec
-    test
-  )
 
   self.config = config
 

--- a/lib/bima-deployment.rb
+++ b/lib/bima-deployment.rb
@@ -3,6 +3,7 @@ require 'logger'
 require 'rake'
 
 require 'bima_deployment/version'
+require 'bima_deployment/errors'
 require 'bima_deployment/configuration'
 require 'bima_deployment/deployment'
 require 'bima_deployment/package'

--- a/lib/bima_deployment/configuration.rb
+++ b/lib/bima_deployment/configuration.rb
@@ -1,8 +1,7 @@
 module BimaDeployment
   class Configuration
     attr_accessor :logger, :configuration_file
-    attr_accessor :deployment, :notification
-    attr_accessor :excluded, :included
+    attr_accessor :deployment, :notification, :package
     attr_accessor :s3
   end
 end

--- a/lib/bima_deployment/errors.rb
+++ b/lib/bima_deployment/errors.rb
@@ -1,0 +1,4 @@
+module BimaDeployment
+  class Error < StandardError; end
+  class ChildProcessError < Error; end
+end

--- a/lib/bima_deployment/package.rb
+++ b/lib/bima_deployment/package.rb
@@ -1,6 +1,7 @@
 module BimaDeployment
   class Package
     attr_accessor :git_tag, :logger
+    attr_reader   :included, :excluded
 
     def self.package_dir(base_dir = git_repository)
       File.join(base_dir, 'tmp', 'package')
@@ -24,6 +25,9 @@ module BimaDeployment
       bucket_name = BimaDeployment.config.s3[:bucket_name]
       region = BimaDeployment.config.s3[:region]
       @s3_bucket = Aws::S3::Bucket.new(bucket_name, region: region)
+
+      @included = BimaDeployment.config.package[:included] || []
+      @excluded = BimaDeployment.config.package[:excluded] || []
     end
 
     def package_dir
@@ -73,7 +77,7 @@ module BimaDeployment
       end
 
       # include files or directories
-      BimaDeployment.config.included.each do |name|
+      included.each do |name|
         src = File.join(git_repository, name)
         dest = File.join(package_dir, name)
 
@@ -87,7 +91,7 @@ module BimaDeployment
       end
 
       # excluded files and directories
-      BimaDeployment.config.excluded.each do |name|
+      excluded.each do |name|
         path = File.join(package_dir, name)
 
         if File.exists?(path)
@@ -133,7 +137,8 @@ module BimaDeployment
       end
     end
 
-    protected
+
+    private
 
     attr_reader :git_repository, :package_archive, :s3_bucket
 

--- a/lib/bima_deployment/package.rb
+++ b/lib/bima_deployment/package.rb
@@ -162,7 +162,10 @@ module BimaDeployment
       options[:verbose] ||= true
 
       logger.info(command) if options[:verbose]
-      %x(#{command})
+      output  = %x(#{command})
+      raise ChildProcessError.new(output)  unless $?.success?
+
+      output
     end
   end
 end

--- a/lib/bima_deployment/package.rb
+++ b/lib/bima_deployment/package.rb
@@ -66,9 +66,11 @@ module BimaDeployment
         sh "rsync -a #{git_repository}/client/node_modules client/." if client_app?
 
         Bundler.with_clean_env do
-          sh "bundle install --quiet --without development test"
-          sh 'bundle package --quiet'
+          sh 'bundle package --all --quiet'
+          sh 'bundle install --quiet --without development test'
+          sh 'bundle config --local cache_all false'
         end
+
 
         if client_app?
           sh 'cd client && npm install > /dev/null'

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -9,9 +9,14 @@ namespace :deploy do
       BimaDeployment.load_configuration(environment)
       git_tag = args[:git_tag] || default_git_tag
       deployment = BimaDeployment::Deployment.new(environment, git_tag)
-      deployment.confirm
-      deployment.deploy
-      deployment.notify
+
+      begin
+        deployment.confirm
+        deployment.deploy
+        deployment.notify
+      rescue BimaDeployment::ChildProcessError
+        exit(1)
+      end
     end
   end
 end

--- a/lib/tasks/package.rake
+++ b/lib/tasks/package.rake
@@ -29,6 +29,11 @@ task :package, [:git_tag] do |_, args|
     package:upload
     package:cleanup
   ).each do |task|
-    Rake::Task[task].invoke(git_tag)
+    begin
+      Rake::Task[task].invoke(git_tag)
+    rescue BimaDeployment::ChildProcessError
+      exit(1)
+    end
   end
+
 end

--- a/lib/templates/config/deployment.yml
+++ b/lib/templates/config/deployment.yml
@@ -5,6 +5,16 @@ defaults:
     slack:
       url: '<%= options[:slack] %>'
       enabled: <%= options[:notifications] %>
+  package: &package_defaults
+    included: []
+    excluded:
+      - '.gitignore'
+      - '.travis.yml'
+      - '.rspec'
+      - '.git'
+      - 'client/node_modules'
+      - 'spec'
+      - 'test'
 
 development:
   deployment:
@@ -12,6 +22,8 @@ development:
     stack: '<%= name %> (Staging)'
     app: '<%= name.downcase %>_develop'
   notification:
+  package:
+    <<: *package_defaults
 
 staging:
   deployment:
@@ -19,6 +31,8 @@ staging:
     stack: '<%= name %> (Staging)'
     app: '<%= name.downcase %>_staging'
   notification:
+  package:
+    <<: *package_defaults
 
 production:
   deployment:
@@ -27,3 +41,5 @@ production:
     app: '<%= name.downcase %>'
   notification:
     <<: *notification_defaults
+  package:
+    <<: *package_defaults


### PR DESCRIPTION
1. Updated README
1. Remove `included` and `excluded` from configuration.
1. Add new option `package` to configuration, which wraps the former `included` and `excluded`.
1. Remove logic for initializer `deployment.rb`.
1. Add package defaults to template `deployment.yml`.
1. Fix deployment problem with “bundle pack —all”
    (Fixes `https://github.com/jdahlke/bima-deployment.git (at 2.0.3@bb823c5) is not yet checked out. Run bundle install first.`)
